### PR TITLE
Add oc_wm_request module with make_req_id/0

### DIFF
--- a/src/oc_wm_request.erl
+++ b/src/oc_wm_request.erl
@@ -1,0 +1,29 @@
+%% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92-*-
+%% ex: ts=4 sw=4 et
+%%
+%% Copyright 2013 Opscode, Inc.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+
+-module(oc_wm_request).
+
+-export([
+         make_req_id/0
+        ]).
+
+%% @doc Generate a new random identifier for requests.
+-spec make_req_id() -> <<_:192>>. %% 24 bytes
+make_req_id() ->
+    base64:encode(crypto:md5(term_to_binary(make_ref()))).


### PR DESCRIPTION
I'm thinking this is probably the place for this functionality now.

This originally comes from [chef_wm_base:read_req_id/2](https://github.com/opscode/chef_wm/blob/master/src/chef_wm_base.erl#L493).  I ended up duplicating it in [chef_reindex:make_req_id/0](https://github.com/opscode/chef_wm/blob/master/src/chef_reindex.erl#L55-L63), and now have a need for it in the OPC reindexing logic.  I figure now's the time to extract this.

Open to additional suggestions.  I'm basing this off @hosh's request logger branch for the sole reason that he's already done the work to make this a library, and I didn't feel like duplicating effort; beyond that infrastructure, it has no "true" dependency on that branch.  I can rebase as necessary.
