### PR TITLE
Request Logger: Don't Print "empty_string" to Logs

### DIFF
--- a/src/oc_wm_request_logger.erl
+++ b/src/oc_wm_request_logger.erl
@@ -159,6 +159,8 @@ message_annotations(Annotations, Notes) ->
 %% If the value is undefined, then emit nothing.
 format_note(_Key, undefined) ->
     [];
+format_note(_Key, "") ->
+    [];
 format_note(_ParentKey, [{_, _} | _] = Proplist) ->
     %% If it is a proplist, then expand it out and drop the parent key
     [format_note(Key, Value) || {Key, Value} <- Proplist];

--- a/test/oc_wm_request_logger_tests.erl
+++ b/test/oc_wm_request_logger_tests.erl
@@ -20,6 +20,7 @@
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("webmachine/include/webmachine_logger.hrl").
 -include_lib("sample_requests.hrl").
+-compile([export_all]).
 
 valid_log_data() ->
   #wm_log_data{response_code = <<"200">>,
@@ -94,6 +95,28 @@ valid_message_format_test_() ->
       end
     }
   ].
+
+format_test_() ->
+    [
+     {"formatter returns empty list when value is undefined",
+      ?_assertEqual([], oc_wm_request_logger:format_note(key, undefined))
+     },
+     {"formatter returns empty list when value is empty string",
+      ?_assertEqual([], oc_wm_request_logger:format_note(key, ""))
+     },
+     {"formatter returns empty list when value is empty list",
+      ?_assertEqual([], oc_wm_request_logger:format_note(key, []))
+     },
+     {"formatter removes empty and undefined values from proplist",
+      fun() ->
+              PropList = [{key1, undefined},
+                          {key2, ""},
+                          {key3, "value3"}],
+              Result = iolist_to_binary(oc_wm_request_logger:format_note(proplist, PropList)),
+              ?assertEqual(<<"key3=value3; ">>, Result)
+      end
+     }
+    ].
 
 integration_test_() ->
     [{"request logger should create a log file and write to disk",


### PR DESCRIPTION
Now that the darklaunch flags are being removed from EC and HEC we're starting to see logs that show `darklaunch=empty_string` show up. I tracked it down to this piece of code that's translating `""` to `"empty_string"`. This PR fixes that and adds a few tests around how we format the error messages.

ping @seth @hosh
