### PR TITLE
handle all forms of new log message webmachine might send us

### DIFF
--- a/src/oc_wm_request_logger.erl
+++ b/src/oc_wm_request_logger.erl
@@ -124,8 +124,10 @@ generate_msg(#wm_log_data{response_code = ResponseCode,
     %% Our list of things to log, manually extracted from our log_data record
     %% This format is suitable for splunk parsing.
     Code = case ResponseCode of
-               {C, _} ->
-                   C;
+               {C1, _} when is_integer(C1) ->
+                   C1;
+               {_, C2} ->
+                   C2;
                _ ->
                    ResponseCode
            end,

--- a/test/oc_wm_request_logger_tests.erl
+++ b/test/oc_wm_request_logger_tests.erl
@@ -94,7 +94,7 @@ valid_message_format_test_() ->
           ?assertEqual(undefined, oc_wm_request_logger:note(notreal, Notes))
       end
     },
-   {"Handles annotated response codes from webmachine",
+   {"Handles annotated non-error response codes from webmachine",
     %% wm 1.10.5 introduced customizable response status
     %% messages. This means that the logger receives `{Code, Msg}'
     fun() ->
@@ -103,6 +103,21 @@ valid_message_format_test_() ->
             ExpectedMsg = iolist_to_binary([<<"method=">>,<<"GET">>,<<"; ">>,
                                             <<"path=">>,<<"this/is/the-path">>,<<"; ">>,
                                             <<"status=">>,<<"200">>,<<"; ">>]),
+            AnnotationFields = [],
+            ActualMsg = oc_wm_request_logger:generate_msg(LogData, AnnotationFields),
+            ?assertEqual(ExpectedMsg, iolist_to_binary(ActualMsg))
+    end
+   },
+
+   {"Handles annotated error response codes from webmachine",
+    %% wm 1.10.5 introduced customizable response status
+    %% messages. This means that the logger receives `{atom, Code}' in the case of error
+    fun() ->
+            LogData0 = valid_log_data(),
+            LogData = LogData0#wm_log_data{response_code = {log_error, 400}},
+            ExpectedMsg = iolist_to_binary([<<"method=">>,<<"GET">>,<<"; ">>,
+                                            <<"path=">>,<<"this/is/the-path">>,<<"; ">>,
+                                            <<"status=">>,<<"400">>,<<"; ">>]),
             AnnotationFields = [],
             ActualMsg = oc_wm_request_logger:generate_msg(LogData, AnnotationFields),
             ?assertEqual(ExpectedMsg, iolist_to_binary(ActualMsg))


### PR DESCRIPTION
Looks like in addition to sending {Code, msg}, webmachine can now also
send us {atom, Code}.  Added handling for the same.

ping @seth 
