### PR TITLE
Update to chef/webmachine for testing

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -4,7 +4,7 @@
 
 {deps,
     [{webmachine, ".*",
-       {git, "git://github.com/webmachine/webmachine", {branch, "master"}}}
+       {git, "git://github.com/chef/webmachine", {branch, "master"}}}
     ]
 }.
 


### PR DESCRIPTION
Pointing to the chef/webmachine fork until PR (https://github.com/webmachine/webmachine/pull/285/files) to webmachine/webmachine is merged.

Please revert once ^^ is merged. 