### PR TITLE
use erlang:md5 instead of crypto md5 to support FIPS

### DIFF
--- a/src/oc_wm_request.erl
+++ b/src/oc_wm_request.erl
@@ -41,7 +41,7 @@ add_notes([{Key, Value} | Rest], Req) ->
 %% @doc Generate a new random identifier for requests.
 -spec make_req_id() -> <<_:192>>. %% 24 bytes
 make_req_id() ->
-    base64:encode(crypto:hash(md5, term_to_binary(make_ref()))).
+    base64:encode(erlang:md5(term_to_binary(make_ref()))).
 
 %% @doc Helper function to get req_id, usually set upstream. (Usually X-Request-Id)
 %% If no req id is set in the header, then one is randomly generated


### PR DESCRIPTION
Signed-off-by: Prajakta Purohit <prajakta@chef.io>

crypto:md5 in not supported in FIPS mode and causes errors.
Replace it with erlang:md5
This will let us use crypto from erlang instead of the patch that is currently used in chef-server

Will help solve: chef/chef-server#1877

Webmachine is already updated with the same changes. rebar.config points to the master of chef/webmachine

Builds and tests for FIPS and non FIPS seem to be working fine:
https://buildkite.com/chef/chef-chef-server-master-omnibus-adhoc/builds/1033#7c68b428-a0a0-4f7a-8a42-90bdeb836a2f

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
