### PR TITLE
remove tuple calls for OPT-21+ support

### DIFF
--- a/src/oc_wm_request_logger.erl
+++ b/src/oc_wm_request_logger.erl
@@ -255,24 +255,24 @@ as_io({raw, X}) ->
 as_io({Fmt, Args}) when is_list(Fmt) andalso is_list(Args) ->
     io_lib:format(Fmt, Args).
 
-wm_method({webmachine_request, _} = Req) ->
-    {Method, _} = Req:method(),
+wm_method({webmachine_request, Req}) ->
+    {Method, _} = webmachine_request:method(Req),
     Method;
 wm_method(#wm_reqdata{} = Req) ->
     wrq:method(Req);
 wm_method(_) ->
     undefined.
 
-wm_path({webmachine_request, _} = Req) ->
-    {Path, _} = Req:path(),
+wm_path({webmachine_request, Req}) ->
+    {Path, _} = webmachine_request:path(Req),
     Path;
 wm_path(#wm_reqdata{} = Req) ->
     wrq:path(Req);
 wm_path(_) ->
     undefined.
 
-wm_notes({webmachine_request, _} = Req) ->
-    {ReqData, _} = Req:get_reqdata(),
+wm_notes({webmachine_request, Req}) ->
+    {ReqData, _} = webmachine_request:get_reqdata(Req),
     wrq:get_notes(ReqData);
 wm_notes(#wm_reqdata{} = Req) ->
     wrq:get_notes(Req);


### PR DESCRIPTION
OTP-21+ removed support for tuple calls by default. While there is a
compile flag we could turn on for compatibility, these calls all
looked straightforward to replace as the function head was already
exactly matching on the module name.

Without this change, we were seeing the logger crash on Erlang 21
with:

```
gen_event oc_wm_request_logger installed in webmachine_log_event terminated with reason: bad argument in call to
erlang:apply({webmachine_request,{wm_reqstate,#Port<0.2501>,[{resource_module,oc_chef_wm_named_user}],undefined,...}},
method, []) in oc_wm_request_logger:wm_method/1 line 259
```

Signed-off-by: Steven Danna <steve@chef.io>