### PR TITLE
WIP Fix multiple issues

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -4,7 +4,7 @@
 
 {deps,
     [{webmachine, ".*",
-       {git, "https://github.com/chef/webmachine", {branch, "master"}}}
+       {git, "https://github.com/chef/webmachine", {branch, "lbaker/updates"}}}
     ]
 }.
 

--- a/src/oc_wm_request_logger.erl
+++ b/src/oc_wm_request_logger.erl
@@ -81,7 +81,7 @@
 -define(DEFAULT_ANNOTATIONS, []). %% By default, add nothing extra to the log output
 
 -ifdef(TEST).
--compile(export_all).
+-compile([export_all, nowarn_export_all]).
 -endif.
 
 -type log_annotation() :: {atom(), binary()}.

--- a/test/oc_wm_request_logger_tests.erl
+++ b/test/oc_wm_request_logger_tests.erl
@@ -22,7 +22,7 @@
 -include_lib("webmachine/include/wm_reqdata.hrl").
 -include_lib("webmachine/include/wm_reqstate.hrl").
 -include_lib("sample_requests.hrl").
--compile([export_all]).
+-compile([export_all, nowarn_export_all]).
 
 valid_log_data() ->
   #wm_log_data{response_code = 200,


### PR DESCRIPTION
- won't compile (multiple issues)
- won't run eunit tests
- rebar3 won't pull down dependencies (stuck on webmachine)
- compilation error (erlang:now deprecation)
```
===> Compiling test/oc_wm_request_writer_tests.erl failed
test/oc_wm_request_writer_tests.erl:27:29: erlang:now/0 is deprecated; see the "Time and Time Correction in Erlang" chapter of the ERTS User's Guide for more information
```
