### PR TITLE
CHEF-30519 Update and standardize copyright notices to Progress Software Corporation - copyright_update

### DIFF
--- a/COPYRIGHT.md
+++ b/COPYRIGHT.md
@@ -1,0 +1,1 @@
+Copyright (c) 2013-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.

--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@ All files in the repository are licensed under the Apache 2.0 license. If any
 file is missing the License header it should assume the following is attached;
 
 ```
-Copyright 2014 Chef Software Inc
-
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -113,7 +111,6 @@ Helper repos should follow these guidelines:
 
 |                      |                                          |
 |:---------------------|:-----------------------------------------|
-| **Copyright:**       | Copyright (c) 2013 Opscode, Inc.
 | **License:**         | Apache License, Version 2.0
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -128,4 +125,5 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-
+# Copyright
+See [COPYRIGHT.md](./COPYRIGHT.md).

--- a/doc/oc_wm_request_logger.md
+++ b/doc/oc_wm_request_logger.md
@@ -7,7 +7,7 @@
 
 
 Per-Request Logger for Webmachine.
-Copyright (c) 2013 Opscode Inc.
+Copyright (c) 2013-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 
 This file is provided to you under the Apache License,
 Version 2.0 (the "License"); you may not use this file

--- a/src/oc_wm_request.erl
+++ b/src/oc_wm_request.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92-*-
 %% ex: ts=4 sw=4 et
 %%
-%% Copyright 2013 Opscode, Inc.
+%% Copyright (c) 2013-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/oc_wm_request_logger.erl
+++ b/src/oc_wm_request_logger.erl
@@ -3,7 +3,7 @@
 %% ex: ts=4 sw=4 ft=erlang et
 %% @author Matthew Peck <matthew@opscode.com>
 %% @author Ho-Sheng Hsiao <hosh@opscode.com>
-%% @copyright 2013 Opscode Inc.
+%% @Copyright (c) 2013-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/oc_wm_request_writer.erl
+++ b/src/oc_wm_request_writer.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
 %% ex: ts=4 sw=4 et
 %% @author Kevin Smith <kevin@opscode.com>
-%% Copyright 2011-2012 Opscode, Inc. All Rights Reserved.
+%% Copyright (c) 2013-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/test/oc_wm_request_logger_tests.erl
+++ b/test/oc_wm_request_logger_tests.erl
@@ -1,4 +1,4 @@
-%% @copyright 2013 Opscode Inc.
+%% @Copyright (c) 2013-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/test/oc_wm_request_writer_tests.erl
+++ b/test/oc_wm_request_writer_tests.erl
@@ -1,4 +1,4 @@
-%% @copyright 2013 Opscode Inc.
+%% @Copyright (c) 2013-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file


### PR DESCRIPTION
This is an automated message using the copyright-automator tool.

This PR updates copyright notices from Chef Software and Opscode to Progress Software Corporation as part of the repository standardization effort.

## Automated Changes

- Updated Opscode, Chef, and Progress copyright notices to use Progress Software Corporation current language
- Applied year range: 2013-2025 reflecting our understanding of repo-specific activity
- Preserved original formatting and comment styles

## Manual Changes Required

⚠️ This PR requires manual intervention for the following files:

- `COPYRIGHT.md:1` - adjust-copyright-file
- `README.md:1` - adjust-readme
- `README.md:11` - adjust-readme
- `README.md:116` - adjust-readme

Please review these locations and make appropriate manual edits.

## No Other Changes Intended

- No change to Author, Contributor, or Maintainer information
- No change to non-PSC copyright holders
