### PR TITLE
CHEF-20751: Add configurable log_rotation_type to request logger

### DIFF
--- a/src/oc_wm_request_logger.erl
+++ b/src/oc_wm_request_logger.erl
@@ -31,7 +31,8 @@
 %%     {oc_wm_request_logger, [
 %%                                 {file, "/tmp/requests.log"},
 %%                                 {file_size, 100},  %% Size in MB
-%%                                 {files, 5}
+%%                                 {files, 5},
+%%                                 {log_rotation_type, rotate}  %% Optional; default is 'wrap'
 %%                                ]
 %%     }]
 %%   } ]
@@ -39,10 +40,15 @@
 %%
 %% Available configuration keys:
 %%
-%% file        - Base file name to log to
-%% file_size   - Maximum size of log files in rotation, in MB
-%% files       - Number of log files in rotation
-%% annotations - (optional) Values to pull out of the Notes section. This is a list of atoms
+%% file              - Base file name to log to
+%% file_size         - Maximum size of log files in rotation, in MB
+%% files             - Number of log files in rotation
+%% log_rotation_type - (optional) 'wrap' (default) or 'rotate' (requires OTP 26+)
+%%                     'wrap'   : numbered segment files (requests.log.1, .2, …); basename is
+%%                                NOT the latest file
+%%                     'rotate' : plain basename (requests.log) is always the active file;
+%%                                rotated archives are requests.log.0.gz (newest), .1.gz, …
+%% annotations       - (optional) Values to pull out of the Notes section. This is a list of atoms
 %%
 %%               Example:
 %%
@@ -79,6 +85,7 @@
 -define(DEFAULT_MAX_FILE_SIZE, 100). %% in MB
 -define(DEFAULT_NUM_FILES, 3).
 -define(DEFAULT_ANNOTATIONS, []). %% By default, add nothing extra to the log output
+-define(DEFAULT_LOG_ROTATION_TYPE, wrap).
 
 -ifdef(TEST).
 -compile([export_all, nowarn_export_all]).
@@ -99,7 +106,8 @@ init(LogConfig) ->
     FileSize = proplists:get_value(file_size, LogConfig, ?DEFAULT_MAX_FILE_SIZE),
     FileCount = proplists:get_value(files, LogConfig, ?DEFAULT_NUM_FILES),
     Annotations = proplists:get_value(annotations, LogConfig, ?DEFAULT_ANNOTATIONS),
-    {ok, LogHandle} = oc_wm_request_writer:open("request_log", FileName, FileCount, FileSize),
+    LogRotationType = proplists:get_value(log_rotation_type, LogConfig, ?DEFAULT_LOG_ROTATION_TYPE),
+    {ok, LogHandle} = oc_wm_request_writer:open("request_log", FileName, FileCount, FileSize, LogRotationType),
     {ok, #state{log_handle = LogHandle, annotations = Annotations}}.
 
 handle_call(_Msg, State) ->

--- a/src/oc_wm_request_writer.erl
+++ b/src/oc_wm_request_writer.erl
@@ -24,6 +24,7 @@
 -include_lib("kernel/src/disk_log.hrl").
 
 -export([open/4,
+         open/5,
          write/2]).
 
 -type calendar_time() :: { non_neg_integer(),  non_neg_integer(),  non_neg_integer() }.
@@ -41,10 +42,28 @@
 -spec(open(string(), string(), pos_integer(), pos_integer()) ->
              {ok, #continuation{}} | {error, any()}).
 open(Name, FileName, MaxFiles, MaxFileSize) ->
+    open(Name, FileName, MaxFiles, MaxFileSize, wrap).
+
+%% @doc Helper function to open a disk log with a configurable rotation type.
+%%
+%% Arguments:
+%%   Name            - Name of the log, referred internally
+%%   FileName        - Base filename on disk
+%%   MaxFiles        - Maximum number of log files in rotation
+%%   MaxSize         - Maximum size of each log file in rotation (in MB)
+%%   LogRotationType - Rotation type: 'wrap' (default) or 'rotate' (OTP 26+)
+%%
+%% When LogRotationType is 'rotate', the active file is always the plain
+%% FileName basename, and rotated archives are named FileName.N.gz
+%% (where .0.gz is the most recent). Requires OTP 26 or later.
+%%
+-spec(open(string(), string(), pos_integer(), pos_integer(), wrap | rotate) ->
+             {ok, #continuation{}} | {error, any()}).
+open(Name, FileName, MaxFiles, MaxFileSize, LogRotationType) ->
     disk_log:open([{name, Name},
                    {file, FileName},
                    {size, {MaxFileSize * 1024 * 1024, MaxFiles}},
-                   {type, wrap},
+                   {type, LogRotationType},
                    {format, external}]).
 
 -spec write(Log :: #continuation{},

--- a/test/oc_wm_request_logger_tests.erl
+++ b/test/oc_wm_request_logger_tests.erl
@@ -187,6 +187,47 @@ add_wm_log_handler() ->
                                                   {annotations, [req_id, perf_stats, msg]}]),
     ExpectedLogFilename.
 
+add_wm_log_handler_rotate() ->
+    %% Same as add_wm_log_handler/0 but uses rotate mode.
+    %% In rotate mode the active file is always the plain basename (no .1 suffix).
+    %% Uses a tiny file_size (1 byte effectively, since disk_log rounds up) so
+    %% that a rotation can be forced by writing enough entries.
+    {A, B, C} = now(),
+    LogBasename = io_lib:format("/tmp/opscoderl_wm-test-rotate-~p-~p-~p/request.log", [A, B, C]),
+    filelib:ensure_dir(LogBasename),
+    gen_event:start_link({local, ?EVENT_LOGGER}),
+    webmachine_log:add_handler(oc_wm_request_logger, [{file, LogBasename},
+                                                  {file_size, 1},  %% 1 MB — will rotate after enough writes
+                                                  {files, 3},
+                                                  {log_rotation_type, rotate},
+                                                  {annotations, [req_id, perf_stats, msg]}]),
+    LogBasename. %% plain basename IS the active file in rotate mode
+
+integration_rotate_test_() ->
+    [{"request logger (rotate mode) plain basename is always the active file and rotation produces .0.gz archive",
+        fun() ->
+            File = add_wm_log_handler_rotate(),
+            ArchiveFile = File ++ ".0.gz",
+            %% Write enough data to exceed 1 MB and force at least one rotation.
+            %% Each log line is ~120 bytes; 12000 writes ~ 1.4 MB.
+            lists:foreach(fun(_) ->
+                webmachine_log:log_access(valid_log_data())
+            end, lists:seq(1, 12000)),
+            webmachine_log:delete_handler(oc_wm_request_logger),
+            %% The plain basename must exist and contain log entries (it is the active file)
+            {ok, ActiveLog} = file:read_file(File),
+            ?assertMatch({match, _},
+                         re:run(ActiveLog, "[\\d-]+T[\\d:]+Z .* method=.*; path=.*; status=.*")),
+            %% A rotated archive must exist — this is the key proof that rotation occurred
+            %% and that the plain basename remained the active file throughout
+            ?assertEqual(true, filelib:is_regular(ArchiveFile)),
+            %% The archive must be non-empty gzip data (magic bytes 1f 8b)
+            {ok, ArchiveData} = file:read_file(ArchiveFile),
+            <<16#1f, 16#8b, _/binary>> = ArchiveData,
+            file:delete(File)
+        end
+    }].
+
 as_io_test_() ->
     ExactTests = [
                   {an_atom, <<"an_atom">>},


### PR DESCRIPTION
## Summary

Add a new `log_rotation_type` config key to `oc_wm_request_logger` (default: `wrap`) that controls the `disk_log` rotation style used for request logging.

When set to `rotate` (requires OTP 26+), the plain basename (e.g. `requests.log`) is always the active/current file, and rotated archives are written as `requests.log.0.gz` (newest), `.1.gz`, etc. — which is what the customer in CHEF-20751 wants.

The existing `wrap` behavior is unchanged and remains the default, so no action is required from existing deployments.

## Changes

- **`oc_wm_request_writer.erl`**: `open/4` now delegates to new `open/5` which accepts a `wrap | rotate` atom; `open/4` kept as a backward-compatible wrapper
- **`oc_wm_request_logger.erl`**: reads `log_rotation_type` from config proplist (default `wrap`), passes to `open/5`; doc comment updated with full description of both modes
- **`test/oc_wm_request_logger_tests.erl`**: adds `integration_rotate_test_` which forces a rotation by writing >1 MB of entries and asserts both the active plain-basename file and a `.0.gz` gzip archive exist with valid content

## Testing

All 27 tests pass (`rebar3 eunit`). The new rotate integration test:
1. Writes >1 MB of log entries to force rotation
2. Asserts the plain basename file exists and contains valid log entries
3. Asserts `requests.log.0.gz` exists and has valid gzip magic bytes

## Jira

[CHEF-20751](https://progresssoftware.atlassian.net/browse/CHEF-20751)

This work was completed with AI assistance following Progress AI policies.

[CHEF-20751]: https://progresssoftware.atlassian.net/browse/CHEF-20751?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ